### PR TITLE
Fixes Telescope Issue #1936, added Cache-Control microservice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,8 +1427,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1547,7 +1546,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1794,8 +1792,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "console-log-level": {
       "version": "1.4.1",
@@ -2629,6 +2626,28 @@
         "bser": "2.1.1"
       }
     },
+    "fengari": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
+      "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+      "requires": {
+        "readline-sync": "^1.4.9",
+        "sprintf-js": "^1.1.1",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
+    },
+    "fengari-interop": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.2.tgz",
+      "integrity": "sha512-8iTvaByZVoi+lQJhHH9vC+c/Yaok9CwOqNQZN6JrVpjmWwW4dDkeblBXhnHC+BoI6eF4Cy5NKW3z6ICEjvgywQ=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3047,6 +3066,18 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "ioredis-mock": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.4.1.tgz",
+      "integrity": "sha512-H8yz/ndYvmnz/Vr2ngU01XI59NBq/3QNBmZ3GCyjOuMWVbPfUbhMKZON3Er5JRbU2BZZvAU4+9yW9tu7xLe7XA==",
+      "requires": {
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.2",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "standard-as-callback": "^2.0.1"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3307,6 +3338,15 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -4868,8 +4908,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -5051,7 +5090,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5161,8 +5199,7 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -5414,6 +5451,11 @@
       "requires": {
         "forwarded-parse": "^2.1.0"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -6008,6 +6050,11 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -6814,6 +6861,11 @@
         }
       }
     },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7005,6 +7057,14 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -7369,6 +7429,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,7 +1427,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -1546,6 +1547,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1792,7 +1794,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "console-log-level": {
       "version": "1.4.1",
@@ -1918,6 +1921,13 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "decamelize": {
@@ -2626,28 +2636,6 @@
         "bser": "2.1.1"
       }
     },
-    "fengari": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
-      "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
-      "requires": {
-        "readline-sync": "^1.4.9",
-        "sprintf-js": "^1.1.1",
-        "tmp": "^0.0.33"
-      },
-      "dependencies": {
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-        }
-      }
-    },
-    "fengari-interop": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.2.tgz",
-      "integrity": "sha512-8iTvaByZVoi+lQJhHH9vC+c/Yaok9CwOqNQZN6JrVpjmWwW4dDkeblBXhnHC+BoI6eF4Cy5NKW3z6ICEjvgywQ=="
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3066,18 +3054,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ioredis-mock": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.4.1.tgz",
-      "integrity": "sha512-H8yz/ndYvmnz/Vr2ngU01XI59NBq/3QNBmZ3GCyjOuMWVbPfUbhMKZON3Er5JRbU2BZZvAU4+9yW9tu7xLe7XA==",
-      "requires": {
-        "fengari": "^0.1.4",
-        "fengari-interop": "^0.1.2",
-        "lodash": "^4.17.20",
-        "minimatch": "^3.0.4",
-        "standard-as-callback": "^2.0.1"
-      }
-    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3338,15 +3314,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -4908,7 +4875,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -5090,6 +5058,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5138,9 +5107,9 @@
       "dev": true
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "multimatch": {
       "version": "4.0.0",
@@ -5199,7 +5168,8 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -5451,11 +5421,6 @@
       "requires": {
         "forwarded-parse": "^2.1.0"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -6050,11 +6015,6 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
-    },
-    "readline-sync": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
-      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -6861,11 +6821,6 @@
         }
       }
     },
-    "standard-as-callback": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
-    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7057,14 +7012,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -7429,11 +7376,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "helmet": "4.4.1",
     "http-errors": "^1.8.0",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "jsonwebtoken": "^8.5.1",
 =======
     "ioredis-mock": "^5.4.1",
@@ -36,6 +37,9 @@
 >>>>>>> c335c24... Created HttpHeader Functions
 =======
 >>>>>>> 2c1d621... Clean up packages, code
+=======
+    "ms": "^2.1.3",
+>>>>>>> 418f2d5... Revamped Cache middleware
     "pino": "^6.11.2",
     "pino-colada": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,12 @@
     "express-pino-logger": "^6.0.0",
     "helmet": "4.4.1",
     "http-errors": "^1.8.0",
+<<<<<<< HEAD
     "jsonwebtoken": "^8.5.1",
+=======
+    "ioredis-mock": "^5.4.1",
+    "isomorphic-fetch": "^3.0.0",
+>>>>>>> c335c24... Created HttpHeader Functions
     "pino": "^6.11.2",
     "pino-colada": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,19 +27,7 @@
     "express-pino-logger": "^6.0.0",
     "helmet": "4.4.1",
     "http-errors": "^1.8.0",
-<<<<<<< HEAD
-<<<<<<< HEAD
     "jsonwebtoken": "^8.5.1",
-=======
-    "ioredis-mock": "^5.4.1",
-<<<<<<< HEAD
-    "isomorphic-fetch": "^3.0.0",
->>>>>>> c335c24... Created HttpHeader Functions
-=======
->>>>>>> 2c1d621... Clean up packages, code
-=======
-    "ms": "^2.1.3",
->>>>>>> 418f2d5... Revamped Cache middleware
     "pino": "^6.11.2",
     "pino-colada": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,8 +31,11 @@
     "jsonwebtoken": "^8.5.1",
 =======
     "ioredis-mock": "^5.4.1",
+<<<<<<< HEAD
     "isomorphic-fetch": "^3.0.0",
 >>>>>>> c335c24... Created HttpHeader Functions
+=======
+>>>>>>> 2c1d621... Clean up packages, code
     "pino": "^6.11.2",
     "pino-colada": "^2.1.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 require('./apm');
 
-const { isAuthenticated, isAuthorized } = require('./middleware');
+const { isAuthenticated, isAuthorized, cache } = require('./middleware');
 const { createRouter } = require('./app');
 
 module.exports.Satellite = require('./satellite');
@@ -11,3 +11,4 @@ module.exports.createServiceToken = require('./service-token');
 module.exports.Router = (options) => createRouter(options);
 module.exports.isAuthenticated = isAuthenticated;
 module.exports.isAuthorized = isAuthorized;
+module.exports.cache = cache;

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -117,9 +117,7 @@ function errorHandler(err, req, res, next) {
 function cache(res) {
   this.forever = (res) => {
     const t = ms('1y');
-    //console.log(res);
     res.headers.set(`Cache-Control`, `public, max-age=${t}, immutable`);
-    console.log(res.headers.get('Cache-Control'));
   }; // Forever Function
 
   /*
@@ -128,18 +126,18 @@ we don't want to serve stale resources when Telescope is down.
 see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#requiring_revalidation
 */
   this.never = (res) => {
-    res.set('Cache-Control', 'public, no-store, max-age=0');
+    res.headers.set('Cache-Control', 'public, no-store, max-age=0');
   };
 
   this.duration = (time, res) => {
     const t = ms(time);
-    res.set('Cache-Control', 'public, max-age=${t}');
+    res.headers.set('Cache-Control', `public, max-age=${t}`);
   };
 
   this.staleFor = (time, res) => {
     if (res.headers.get('Cache-Control') !== null) {
       const t = ms(time);
-      res.headers.append('Cache-Control', 'max-stale=${t}');
+      res.headers.append('Cache-Control', `max-stale=${t}`);
     } else {
       next(
         createError(
@@ -153,7 +151,7 @@ see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#req
   this.freshFor = (time, res) => {
     if (res.headers.get('Cache-Control') !== null) {
       const t = ms(time);
-      res.headers.append('Cache-Control', 'min-fresh=${t}');
+      res.headers.append('Cache-Control', `min-fresh=${t}`);
     } else {
       next(
         createError(

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -116,16 +116,17 @@ function setHttpCacheHeaders(cacheObj) {
   /*
  Level 1 - No Caching at all
  Level 2 - Some caching, but for a small time window, 5 minutes
- Level 3 - Regular Caching, store them for a year
+ Level 3 - Regular Caching, store them for a month
  Level 4 - Extreme Caching, store them forever
  */
 
   const options = cacheObj.options;
   const levelValue = cacheObj.level;
   const res = cacheObj.res;
+  const customTime = cacheObj.custom;
 
   // Enum the levels for readability
-  const levels = { LEVEL1: 1, LEVEL2: 2, LEVEL3: 3, LEVEL4: 4 };
+  const levels = { LEVEL1: 1, LEVEL2: 2, LEVEL3: 3, LEVEL4: 4, LEVEL5: 5 };
 
   if (level === null && options === null) {
     next(
@@ -166,6 +167,18 @@ function setHttpCacheHeaders(cacheObj) {
         break;
       case LEVEL4:
         res.set('Cache-Control', 'public, max-age=31536000, immutable');
+        break;
+      case LEVEL5:
+        if (customTime === null || typeof customTime !== 'number' || Number.isNaN(customTime)) {
+          next(
+            createError(
+              500,
+              "You passed a custom value that's not a number. Check the type of `custom`. "
+            )
+          );
+        } else {
+          res.set('Cache-Control', 'public, max-age=${customTime}');
+        }
         break;
     }
     //Add any additional options left over from the user.

--- a/test.js
+++ b/test.js
@@ -15,10 +15,13 @@ const {
   hash,
   createError,
 <<<<<<< HEAD
+<<<<<<< HEAD
   createServiceToken,
 =======
   Redis,
 >>>>>>> c335c24... Created HttpHeader Functions
+=======
+>>>>>>> 2c1d621... Clean up packages, code
 } = require('./src');
 const { throwIfCommandIsNotAllowed } = require('ioredis-mock/lib/command');
 const { setHttpCacheHeaders } = require('./src/middleware');

--- a/test.js
+++ b/test.js
@@ -16,12 +16,16 @@ const {
   createError,
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   createServiceToken,
 =======
   Redis,
 >>>>>>> c335c24... Created HttpHeader Functions
 =======
 >>>>>>> 2c1d621... Clean up packages, code
+=======
+  cache,
+>>>>>>> 418f2d5... Revamped Cache middleware
 } = require('./src');
 const { request } = require('http');
 const { JWT_EXPIRES_IN, JWT_ISSUER, JWT_AUDIENCE, SECRET } = process.env;
@@ -834,49 +838,42 @@ describe('Satellite()', () => {
       });
       helmetService.start(port, async () => {
         const res = await fetch(`${url}/always-200`);
+        // console.log(res);
         expect(res.ok).toBe(true);
         expect(res.headers.get('x-xss-protection')).toBe(null);
         helmetService.stop(done);
       });
     });
   });
-});
 
-describe('logger', () => {
-  test('logger should have expected methods()', () => {
-    ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach((level) => {
-      expect(typeof logger[level] === 'function').toBe(true);
-      expect(() => logger[level]('test')).not.toThrow();
+  describe('cache', () => {
+    test('forever() should set the max-age to 1y, and add the immutable tag', (done) => {
+      const service = createSatelliteInstance({
+        name: 'header-test',
+        port,
+      });
+      //router = service.router;
+      service.start(port, async () => {
+        const res = await fetch(`${url}/always-200`);
+        expect(res.ok).toBe(true);
+        cache().forever(res);
+        console.log(res.headers.get('Cache-Control'));
+        expect(res.headers.get('Cache-Control')).toBe('public, max-age=31557600000, immutable');
+        service.stop(done);
+      });
     });
   });
-});
 
-describe('hash', () => {
-  it('should return a 10 character hash value', () => {
-    expect(hash('satellite').length).toBe(10);
+  describe('logger', () => {
+    test('logger should have expected methods()', () => {
+      ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach((level) => {
+        expect(typeof logger[level] === 'function').toBe(true);
+        expect(() => logger[level]('test')).not.toThrow();
+      });
+    });
   });
 
-  it('should hash a string correctly', () => {
-    expect(hash('satellite')).toBe('dc4b4e203f');
-  });
-
-  it('should return a different hash if anything changes', () => {
-    expect(hash('satellite2')).toBe('6288d4ca65');
-  });
-});
-
-describe('Create Error tests for Satellite', () => {
-  test('should be an instance of type Error', () => {
-    expect(createError(404, 'testing') instanceof Error).toBe(true);
-  });
-
-  test("should have it's value, and message accessible through it's members", () => {
-    const testError = createError(404, 'Satellite Test for Errors');
-    expect(testError.status).toBe(404);
-    expect(testError.message).toBe('Satellite Test for Errors');
-  });
-});
-
+<<<<<<< HEAD
 <<<<<<< HEAD
 describe('createServiceToken()', () => {
   test('should create a service token', () => {
@@ -894,43 +891,32 @@ describe('Sets headers for a Response object', () => {
   test('Should set the object to Level 3 Caching', () => {
     const service = createSatelliteInstance({
       name: 'header-test',
+=======
+  describe('hash', () => {
+    it('should return a 10 character hash value', () => {
+      expect(hash('satellite').length).toBe(10);
+>>>>>>> 418f2d5... Revamped Cache middleware
     });
-    router = service.router;
-    router.get('/public', (req, res) => {
-      setHttpCacheHeaders({ res: res, level: 3 });
-      expect(res.headers.get('Access-Control-Max-Age')).toBe('2592000');
+
+    it('should hash a string correctly', () => {
+      expect(hash('satellite')).toBe('dc4b4e203f');
     });
-  });
-  test('Should allow us to set options unrelated to Cache-Control', () => {
-    const service = createSatelliteInstance({
-      name: 'header-test-2',
-    });
-    router = service.router;
-    router.get('/public', (req, res) => {
-      setHttpCacheHeaders({
-        res: res,
-        options: { 'content-type': 'image/jpeg', 'x-content-type-options': 'nosniff' },
-        level: 3,
-      });
-      expect(res.headers.get('Access-Control-Max-Age')).toBe('2592000');
-      expect(res.headers.get('Content-Type')).toBe('image/jpeg');
-      expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+
+    it('should return a different hash if anything changes', () => {
+      expect(hash('satellite2')).toBe('6288d4ca65');
     });
 >>>>>>> c335c24... Created HttpHeader Functions
   });
-  test('Allows us to use a custom time value for max-age', () => {
-    const service = createSatelliteInstance({
-      name: 'header-test-3',
+
+  describe('Create Error tests for Satellite', () => {
+    test('should be an instance of type Error', () => {
+      expect(createError(404, 'testing') instanceof Error).toBe(true);
     });
-    router = service.router;
-    router.get('/public', (req, res) => {
-      setHttpCacheHeaders({
-        res: res,
-        options: { 'content-type': 'image/jpeg', 'x-content-type-options': 'nosniff' },
-        level: 5,
-        custom: 600,
-      });
-      expect(res.headers.get('Access-Control-Max-Age')).toBe('600');
+
+    test("should have it's value, and message accessible through it's members", () => {
+      const testError = createError(404, 'Satellite Test for Errors');
+      expect(testError.status).toBe(404);
+      expect(testError.message).toBe('Satellite Test for Errors');
     });
   });
 });

--- a/test.js
+++ b/test.js
@@ -852,13 +852,38 @@ describe('Satellite()', () => {
         name: 'header-test',
         port,
       });
-      //router = service.router;
       service.start(port, async () => {
         const res = await fetch(`${url}/always-200`);
         expect(res.ok).toBe(true);
         cache().forever(res);
-        console.log(res.headers.get('Cache-Control'));
         expect(res.headers.get('Cache-Control')).toBe('public, max-age=31557600000, immutable');
+        service.stop(done);
+      });
+    });
+    test('never() should set max-age to 0, and contain no-store', (done) => {
+      const service = createSatelliteInstance({
+        name: 'header-test-2',
+        port,
+      });
+      service.start(port, async () => {
+        const res = await fetch(`${url}/always-200`);
+        expect(res.ok).toBe(true);
+        cache().never(res);
+        expect(res.headers.get('Cache-Control')).toBe('public, no-store, max-age=0');
+        service.stop(done);
+      });
+    });
+
+    test('duration() should set max-age to a certain value', (done) => {
+      const service = createSatelliteInstance({
+        name: 'header-test-3',
+        port,
+      });
+      service.start(port, async () => {
+        const res = await fetch(`${url}/always-200`);
+        expect(res.ok).toBe(true);
+        cache().duration('1d', res);
+        expect(res.headers.get('Cache-Control')).toBe('public, max-age=86400000');
         service.stop(done);
       });
     });

--- a/test.js
+++ b/test.js
@@ -14,8 +14,15 @@ const {
   logger,
   hash,
   createError,
+<<<<<<< HEAD
   createServiceToken,
+=======
+  Redis,
+>>>>>>> c335c24... Created HttpHeader Functions
 } = require('./src');
+const { throwIfCommandIsNotAllowed } = require('ioredis-mock/lib/command');
+const { setHttpCacheHeaders } = require('./src/middleware');
+const { request } = require('http');
 const { JWT_EXPIRES_IN, JWT_ISSUER, JWT_AUDIENCE, SECRET } = process.env;
 
 const createSatelliteInstance = (options) => {
@@ -869,6 +876,7 @@ describe('Create Error tests for Satellite', () => {
   });
 });
 
+<<<<<<< HEAD
 describe('createServiceToken()', () => {
   test('should create a service token', () => {
     const token = createServiceToken();
@@ -880,5 +888,33 @@ describe('createServiceToken()', () => {
 
     const currentDateSeconds = Date.now() / 1000;
     expect(decoded.exp).toBeGreaterThan(currentDateSeconds);
+=======
+describe('Sets headers for a Response object', () => {
+  test('Should set the object to Level 3 Caching', () => {
+    const service = createSatelliteInstance({
+      name: 'header-test',
+    });
+    router = service.router;
+    router.get('/public', (req, res) => {
+      setHttpHeaders({ res: res, level: 3 });
+      expect(res.headers.get('Access-Control-Max-Age')).toBe('2592000');
+    });
+  });
+  test('Should allow us to set options unrelated to Cache-Control', () => {
+    const service = createSatelliteInstance({
+      name: 'header-test-2',
+    });
+    router = service.router;
+    router.get('/public', (req, res) => {
+      setHttpHeaders({
+        res: res,
+        options: { 'content-type': 'image/jpeg', 'x-content-type-options': 'nosniff' },
+        level: 3,
+      });
+      expect(res.headers.get('Access-Control-Max-Age')).toBe('2592000');
+      expect(res.headers.get('Content-Type')).toBe('image/jpeg');
+      expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    });
+>>>>>>> c335c24... Created HttpHeader Functions
   });
 });

--- a/test.js
+++ b/test.js
@@ -23,7 +23,6 @@ const {
 =======
 >>>>>>> 2c1d621... Clean up packages, code
 } = require('./src');
-const { throwIfCommandIsNotAllowed } = require('ioredis-mock/lib/command');
 const { setHttpCacheHeaders } = require('./src/middleware');
 const { request } = require('http');
 const { JWT_EXPIRES_IN, JWT_ISSUER, JWT_AUDIENCE, SECRET } = process.env;
@@ -899,7 +898,7 @@ describe('Sets headers for a Response object', () => {
     });
     router = service.router;
     router.get('/public', (req, res) => {
-      setHttpHeaders({ res: res, level: 3 });
+      setHttpCacheHeaders({ res: res, level: 3 });
       expect(res.headers.get('Access-Control-Max-Age')).toBe('2592000');
     });
   });
@@ -909,7 +908,7 @@ describe('Sets headers for a Response object', () => {
     });
     router = service.router;
     router.get('/public', (req, res) => {
-      setHttpHeaders({
+      setHttpCacheHeaders({
         res: res,
         options: { 'content-type': 'image/jpeg', 'x-content-type-options': 'nosniff' },
         level: 3,

--- a/test.js
+++ b/test.js
@@ -23,7 +23,6 @@ const {
 =======
 >>>>>>> 2c1d621... Clean up packages, code
 } = require('./src');
-const { setHttpCacheHeaders } = require('./src/middleware');
 const { request } = require('http');
 const { JWT_EXPIRES_IN, JWT_ISSUER, JWT_AUDIENCE, SECRET } = process.env;
 
@@ -918,5 +917,20 @@ describe('Sets headers for a Response object', () => {
       expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
     });
 >>>>>>> c335c24... Created HttpHeader Functions
+  });
+  test('Allows us to use a custom time value for max-age', () => {
+    const service = createSatelliteInstance({
+      name: 'header-test-3',
+    });
+    router = service.router;
+    router.get('/public', (req, res) => {
+      setHttpCacheHeaders({
+        res: res,
+        options: { 'content-type': 'image/jpeg', 'x-content-type-options': 'nosniff' },
+        level: 5,
+        custom: 600,
+      });
+      expect(res.headers.get('Access-Control-Max-Age')).toBe('600');
+    });
   });
 });


### PR DESCRIPTION
This is a middleware service that addresses the needs for Cache-Control Levels.

### Arguments:
- `res` : The object that will be assigned our Cache-Control levels


#### Cache Durations:
`never(res)` - The `never()` function doesn't not allow caching at all, `max-age` is set as 0, along with `no-store`. 
`duration(time, res)` - Allows a user to set a custom time for `max-age`. 
`forever(res)` - allows caching for up to 1 year, and sets the item as immutable. 

#### Freshness, and Staleness
It's possible to set your Response to a certain freshness, or how long the response can be stale for.

`freshFor(time, res)` - Sets the amount of time a response could be fresh for.
`staleFor(time, res)` - Sets the amount of time a response could be stale for.

When calling our Cache Control functions, this is how you call the functions/
For example, 

```js
cache().forever(res); // Sets max-age to 1 year forever
cache().duration('1m', res); // Sets max-age to 1 month
```
