### PR TITLE
Add support for generating a service token

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ router.get('/private-route', isAuthenticated(), (req, res) => {...});
 Here are some examples:
 
 ```js
+const { isAuthenticated, isAuthorized } = require("@senecacdot/satellite");
+
 // Authorize based on `roles`
 router.get('/admin', isAuthenticated(), isAuthorized({ roles: ["admin"] }), (req, res) => {...});
 
@@ -211,6 +213,36 @@ The `hash()` function is a convenience hashing function, which returns a 10 char
 const { hash } = require('@senecacdot/satellite');
 
 const id = hash('http://someurl.com');
+```
+
+### Create Service Token
+
+Services authorize requests using the `isAuthenticated()` and `isAuthorized()` middleware discussed above.
+For the most part, this is meant to be used for the case of user-to-service requests: an authenticated
+user passes a JWT token (acquired via the `auth` service), and uses it to request authorization to some
+protected route.
+
+However, in cases where you need to do a service-to-service request, you can use the `createServiceToken()`
+function in order to get a short-lived access token that will include the `"service"` role:
+
+```js
+const { createServiceToken } = require('@senecacdot/satellite');
+...
+const res = await fetch(`some/protected/route`, {
+  headers: {
+    Authorization: `bearer ${createServiceToken()}`,
+  },
+});
+```
+
+The receiving service can then opt-into allowing this service to be authorized by using
+the `isAuthenticated()` and `isAuthorized()` middleware like so:
+
+```js
+const { isAuthenticated, isAuthorized } = require("@senecacdot/satellite");
+
+// Allow requests with a token bearing the 'service' role to proceed
+router.get('/admin-or-service', isAuthenticated(), isAuthorized({ roles: ["service"] }), (req, res) => {...});
 ```
 
 ### Create Error

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express-pino-logger": "^6.0.0",
     "helmet": "4.4.1",
     "http-errors": "^1.8.0",
+    "jsonwebtoken": "^8.5.1",
     "pino": "^6.11.2",
     "pino-colada": "^2.1.0"
   },
@@ -42,7 +43,6 @@
     "get-port": "^5.1.1",
     "husky": "^5.1.3",
     "jest": "^26.6.3",
-    "jsonwebtoken": "^8.5.1",
     "node-fetch": "^2.6.1",
     "prettier": "2.2.1",
     "pretty-quick": "3.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ module.exports.Satellite = require('./satellite');
 module.exports.logger = require('./logger');
 module.exports.hash = require('./hash');
 module.exports.createError = require('http-errors');
+module.exports.createServiceToken = require('./service-token');
 module.exports.Router = (options) => createRouter(options);
 module.exports.isAuthenticated = isAuthenticated;
 module.exports.isAuthorized = isAuthorized;

--- a/src/service-token.js
+++ b/src/service-token.js
@@ -1,0 +1,22 @@
+const jwt = require('jsonwebtoken');
+
+const { JWT_ISSUER, JWT_AUDIENCE, SECRET } = process.env;
+
+/**
+ * Create a short-lived service-to-service JWT, useful for authorizing
+ * one Telescope microservice with another.  The receiving service has
+ * to opt into this by allowing the 'service' role.
+ * @returns JWT service token
+ */
+function createServiceToken() {
+  const payload = {
+    iss: JWT_ISSUER,
+    aud: JWT_AUDIENCE,
+    sub: 'telescope-service',
+    roles: ['service'],
+  };
+
+  return jwt.sign(payload, SECRET, { expiresIn: '5m' });
+}
+
+module.exports = createServiceToken;


### PR DESCRIPTION
In https://github.com/Seneca-CDOT/telescope/issues/2053 #6, we said that we need a way for a service to contact another service with a JWT.  This adds support for any Satellite-based service to generate a "service token," which each service can optionally allow to do various things at runtime on protected routes.