### PR TITLE
isAuthorized() always takes a function with req, user params

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,39 +158,31 @@ A number of middleware functions are available to help with your routes.
 router.get('/private-route', isAuthenticated(), (req, res) => {...});
 ```
 
-- `isAuthorized()` - used to check if an authenticated user is authorized to something, based either on their role, or a function that compares the user's claims with known values. NOTE: `isAuthorized()` must be used in conjunction with `isAuthenticated()`:
+- `isAuthorized()` - used to check if an authenticated user is authorized. NOTE: `isAuthorized()` must be used in conjunction with `isAuthenticated()`:
 
 Here are some examples:
 
 ```js
 const { isAuthenticated, isAuthorized } = require("@senecacdot/satellite");
 
-// Authorize based on `roles`
-router.get('/admin', isAuthenticated(), isAuthorized({ roles: ["admin"] }), (req, res) => {...});
-
 // Authorize based on arbitrary user claims
 router.post(
   '/:user',
   isAuthenticated(),
-  isAuthorized({
+  isAuthorized(
     // `user` is the decoded payload of the user's token.  Here we use it
     // to make sure that the user param matches the user's `sub` claim,
     // or that the user is an admin.
-    authorizeUser: (user) => {
+    (req, user) => {
       // Check if the user making the request is the same one for the route
       if(user.sub === req.params.user) {
         return true;
       }
 
       // If not, check if they are an admin
-      if(user.roles && user.roles.includes('admin')) {
-        return true;
-      }
-
-      // Otherwise, they can't do this
-      return false;
+      return user.roles.includes('admin');
     }
-  }),
+  ),
   (req, res) => {...}
 );
 ```


### PR DESCRIPTION
I'm working on a PR in Telescope to add authentication/authorization middleware to the Users service.  Doing that, I realized that the `isAuthorized()` middleware needs to be updated to include the `req`, and that it's not practical to do `roles` checks the way I was doing it before.

This updates `isAuthorized()` to always require a function like this:

```js
isAuthorized(function(req, user) {...})
```