### PR TITLE
Fixes Telescope issue #667, Added Cors Delegator Middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2024,6 +2024,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@elastic/ecs-pino-format": "^1.0.0",
     "@godaddy/terminus": "^4.7.0",
     "cors": "2.8.5",
+    "detect-browser": "^5.2.0",
     "elastic-apm-node": "^3.12.1",
     "express": "4.17.1",
     "express-jwt": "^6.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 require('./apm');
 
-const { isAuthenticated, isAuthorized } = require('./middleware');
+const { isAuthenticated, isAuthorized, corsDelegate } = require('./middleware');
 const { createRouter } = require('./app');
 
 module.exports.Satellite = require('./satellite');

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -34,34 +34,56 @@ function validateAuthorizationOptions(options = {}) {
 }
 
 // Check to see if an already Authenticated user is Authorized to do something,
-// based on the `req` and the `user` payload from the access token. For
+// based on: a) their role; b) arbitrary aspects of the user payload. For
 // example, if a user must have the 'admin' role, or a user's `sub` claim
 // must match an expected id. NOTE: isAuthorized() assumes (and depends upon)
 // isAuthenticated() being called first.
-function isAuthorized(authorizeUser) {
-  if (typeof authorizeUser !== 'function') {
-    throw new Error('invalid authorization function');
+function isAuthorized(options) {
+  if (!validateAuthorizationOptions(options)) {
+    throw new Error('invalid authorization options');
   }
 
+  const { roles, authorizeUser } = options;
+
   return function (req, res, next) {
-    const { user } = req;
-    if (!user) {
+    if (!req.user) {
       next(createError(401, `no user or role info`));
       return;
     }
 
     // If these checks fail for any reason, return a 403
     try {
-      if (!authorizeUser(req, user)) {
-        next(createError(403, `user not authorized`));
-      } else {
-        // Authorized, let this proceed.
-        next();
+      const { user } = req;
+
+      // If defined, check that all of the expected roles are present in this user's roles
+      if (roles) {
+        if (!user.roles) {
+          next(createError(403, `user missing roles`));
+          return;
+        }
+        for (const role of roles) {
+          if (!user.roles.includes(role)) {
+            next(createError(403, `user missing required role: ${role}`));
+            return;
+          }
+        }
+      }
+
+      // If defined, check that the user's payload data matches what's expected
+      if (authorizeUser) {
+        if (!authorizeUser(user)) {
+          next(createError(403, `user not authorized`));
+          return;
+        }
       }
     } catch (err) {
       logger.warn({ err }, 'Unexpected error authorizing user');
       next(createError(403, `user not authorized`));
+      return;
     }
+
+    // Authorized, let this proceed.
+    next();
   };
 }
 
@@ -88,6 +110,12 @@ function errorHandler(err, req, res, next) {
   } else {
     res.send(`${err.status} Error: ${err.message}\n`);
   }
+}
+
+function corsDelegate(req, callback, options) {
+  var corsOptions = options;
+  corsOptions['origin'] = true;
+  callback(null, corsOptions);
 }
 
 module.exports.isAuthenticated = isAuthenticated;

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -115,10 +115,8 @@ function errorHandler(err, req, res, next) {
 }
 
 function corsDelegate(req, callback, options) {
-  var corsOptions;
-  corsOptions['origin'] = true;
   try {
-    if (options[exposedHeaders].includes('*')) {
+    if (options['exposedHeaders'].includes('*') || options['allowedHeaders'].includes('*')) {
       if (
         (browser.os === 'Android OS' && browser.name === 'firefox') ||
         browser === 'safari' ||
@@ -137,7 +135,7 @@ function corsDelegate(req, callback, options) {
     }
   } catch (e) {}
 
-  callback(null, corsOptions);
+  callback(null, options);
 }
 
 module.exports.isAuthenticated = isAuthenticated;


### PR DESCRIPTION
Closes https://github.com/Seneca-CDOT/telescope/issues/667

After many trials and tribulations, here's the CORS Delegator that fixes #667 in Telescope

This is a middleware function that will be passed when we configure CORS in Telescope. This is done asynchronously so that we won't have any init issues while the Telescope services start up.

### Layout
 `function corsDelegate(req, callback, options)`
 `req` - The Request Header that will be sent when CORS is being configured
`callback` - the callback function that `corsDelegate` will use when passed as an argument
`options` -  a JSON Object that will contain the different types of headers that we would like to be included when CORS is configured.

### Options Object Members

#### `origin` - Configures the `Access-Control-Allow-Origin` CORS Header. 

**Accepted Values:**
 `bool` - You can set `origin` to `true` to enable the requested Origin in the CORS Response.  Setting this to `false` will disable CORS.
 
 `string` - You cat set `origin` to a specific origin of your choice. Eg, setting `origin` to `www.telescope.cdot.systems` will only accept request from that address.
 
 `RegEx` - You can set `origin` to a Reg Ex pattern, and that will be used to test any address passed into CORS. Eg, the pattern `/telescope\.com$` will only accept addresses ending in `telescope.com`
 
 `Array` - If you wish to use any of the above value types, you may store them onto an array, and pass that instead. Eg, `['telescope.com', '/pattern\.com$']`


#### `method` - Configures the `Access-Control-Allow-Methods` CORS Header.
Accepted Values:
`string` - Accepts a string that's comma-delimited. Eg, `'GET,DELETE,POST'`
`array` - Accepts an array of strings. Eg, `['GET', 'DELETE', 'POST']`


#### `allowedHeaders` - Configures the `Access-Control-Allow-Headers` CORS Header.
Accepted Values:
`string` - Accepts a string that's comma-delimited. Eg, `'Content-Type,Authorization'`
`array` - Accepts an array of strings. Eg,  `['Content-Type','Authorization']`


#### `exposedHeaders` - Configures the `Access-Control-Expose-Headers` CORS Header.
Accepted Values:
`string` - Accepts a string that's comma-delimited. Eg, `'Content-Encoding,X-Kuma-Revision'`
`array` - Accepts an array of strings. Eg,  `['Content-Encoding', 'X-Kuma-Revision']`


#### `credentials` - Configures the `Access-Control-Allow-Credentials` CORS Header.
Accepted Value:
`bool` -  Set this to true to pass this header, otherwise it won't be included

#### `maxAge` - Configures the `Access-Control-Max-Age` CORS Header.
Accepted Value:
`int` - an integer that's above the value of 0, otherwise it won't be included.

#### `preflightContinue` - Pass the Pre-flight response to the next callback.

#### `optionsSuccessStatus` - Returns a status code for successful preflights/OPTIONS requests. (Kept for backward compatibility with old browsers)

### Example of the CORS Delegator Use Case

`app.use(cors(corsDelegate({exposedHeaders: ['X-Total-Count', 'Link'], credentials: true})), function (req, res, next){
res.json({msg: 'CORS is now Enabled for the Backend'});

});`