### PR TITLE
Add automatic, graceful shutdown for Redis and Elastic clients

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,5 +11,5 @@ module.exports.createServiceToken = require('./service-token');
 module.exports.Router = (options) => createRouter(options);
 module.exports.isAuthenticated = isAuthenticated;
 module.exports.isAuthorized = isAuthorized;
-module.exports.Redis = require('./redis');
-module.exports.Elastic = require('./elastic');
+module.exports.Redis = require('./redis').Redis;
+module.exports.Elastic = require('./elastic').Elastic;


### PR DESCRIPTION
While starting to fix https://github.com/Seneca-CDOT/telescope/issues/2207, I realized I could do this automatically in Satellite instead.

This manages all Redis/Elasticsearch clients so that we can automatically close the connections gracefully when the app shuts down.  If there are no open connections, this will be a no-op.