### PR TITLE
chore: include nodejs 16 in the CI build matrix

### DIFF
--- a/.github/workflows/node-js-ci.yml
+++ b/.github/workflows/node-js-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -67,7 +67,7 @@ jobs:
         # Setup .npmrc file to publish to npm
         uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm publish --access=public


### PR DESCRIPTION
To align Satellite's CI with the [recent CI changes](https://github.com/Seneca-CDOT/telescope/pull/2318) in Telescope,  this PR adds nodejs v16.x to Satellite's CI build matrix.