### PR TITLE
Adding ESLint to CI runs

### DIFF
--- a/.github/workflows/node-js-ci.yml
+++ b/.github/workflows/node-js-ci.yml
@@ -9,6 +9,21 @@ on:
       - master
 
 jobs:
+  # Verify that ESLint passes
+  eslint:
+    name: ESLint Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.4.1
+        with:
+          node-version: '14'
+          cache: 'npm'
+      - name: Install dependencies and run eslint
+        run: |
+          npm install
+          npm run eslint
+
   build:
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run prettier-check
+      - run: npm run eslint
       - run: npm test
 
   release:


### PR DESCRIPTION
https://github.com/Seneca-CDOT/satellite/pull/21 recently added ESLint to the project. As a follow up, this adds a new job to run `ESLint` in the CI runs (with caching enabled for node modules).

A new job called `ESLint check` was added to the following workflows:
- `node-js-ci.yml`
- `release.yml`

