### PR TITLE
Remove pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "prettier": "prettier --write \"./**/*.{md,jsx,json,html,css,js,yml}\"",
     "prettier-check": "prettier --check \"./**/*.{md,jsx,json,html,css,js,yml}\"",
     "prepare": "husky install",
-    "pre-commit": "pretty-quick --staged && pnpm lint",
-    "preinstall": "npx only-allow pnpm"
+    "pre-commit": "pretty-quick --staged && pnpm lint"
   },
   "repository": "Seneca-CDOT/satellite",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
Fixes #39 

Removing `"preinstall": "npx only-allow pnpm"` since in telescope the e2e testing is failing because the docker still use `npm`