### PR TITLE
[Telescope #2621] Refactoring elastic.js so mock is exported for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,35 @@ const indexPost = async ({ text, id, title, published, author }) => {
 };
 ```
 
+If `MOCK_ELASTIC=1` is set in the environment variables, the `Elastic()` function creates an instance of [ElasticSearch-mock](https://www.npmjs.com/package/@elastic/elasticsearch-mock) with a `mock` object for testing.
+
+```js
+const client = Elastic();
+const mock = client.mock;
+
+beforeEach(() => mock.clearAll());
+
+afterAll(() => {
+  mock.clearAll();
+});
+
+test('Should mock an API', async () => {
+  mock.add(
+    {
+      method: 'GET',
+      path: '/_cat/indices',
+    },
+    () => {
+      return { status: 'ok' };
+    }
+  );
+
+  const response = await client.cat.indices();
+  expect(response.body).toStrictEqual({ status: 'ok' });
+  expect(response.statusCode).toBe(200);
+});
+```
+
 ### fetch
 
 The `fetch(url, options)` function will initiate an http request to an endpoint url specified by `url` with any options also specified by the `options` parameter.


### PR DESCRIPTION
This is related to [#2621](https://github.com/Seneca-CDOT/telescope/issues/2621) on Telescope for creating tests for Search.

I've refactored `elastic.js` so we will be able to mock tests on Telescope. 

The refactor shouldn't change how the regular ElasticSearch is run.

---
Updates:
- Added tests for mock `Elastic()`. To test run `npm test`
- Added descriptions for mock `Elastic()` in `README.md`