### PR TITLE
update dependency http-errors to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "express": "4.17.3",
     "express-jwt": "6.1.1",
     "helmet": "5.0.2",
-    "http-errors": "1.8.1",
+    "http-errors": "2.0.0",
     "ioredis": "4.28.5",
     "ioredis-mock": "7.1.0",
     "jsonwebtoken": "8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ specifiers:
   express-jwt: 6.1.1
   get-port: 5.1.1
   helmet: 5.0.2
-  http-errors: 1.8.1
+  http-errors: 2.0.0
   husky: 7.0.4
   ioredis: 4.28.5
   ioredis-mock: 7.1.0
@@ -34,7 +34,7 @@ dependencies:
   express: 4.17.3
   express-jwt: 6.1.1
   helmet: 5.0.2
-  http-errors: 1.8.1
+  http-errors: 2.0.0
   ioredis: 4.28.5
   ioredis-mock: 7.1.0_ioredis@4.28.5
   jsonwebtoken: 8.5.1
@@ -1413,6 +1413,11 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /depd/2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /destroy/1.0.4:
     resolution: {integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=}
     dev: false
@@ -2115,6 +2120,17 @@ packages:
       inherits: 2.0.4
       setprototypeof: 1.2.0
       statuses: 1.5.0
+      toidentifier: 1.0.1
+    dev: false
+
+  /http-errors/2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
       toidentifier: 1.0.1
     dev: false
 
@@ -3978,6 +3994,11 @@ packages:
   /statuses/1.5.0:
     resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /statuses/2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
     dev: false
 
   /stoppable/1.1.0:

--- a/src/create-error.js
+++ b/src/create-error.js
@@ -1,16 +1,18 @@
-const _createError = require('http-errors');
+const createError = require('http-errors');
 const { errors } = require('@elastic/elasticsearch');
 
 module.exports = (...args) => {
-  let status;
-  let argToSend;
+  // Set status to 500 by default instead of undefined
+  // https://github.com/jshttp/http-errors/blob/206aa2c15635dc1212c06c279540972aa90e23ea/index.js#L53
+  let status = 500;
+  let argToSend = '';
   let props = {};
   for (let i = 0; i < args.length; i++) {
     let arg = args[i];
     let type = typeof arg;
     // Deal with ElasticSearch Error objects
     if (type === 'object' && arg instanceof errors.ResponseError) {
-      argToSend = _createError(arg.statusCode, `ElasticSearch Error:${arg.name}`, arg.meta);
+      argToSend = createError(arg.statusCode, `ElasticSearch Error:${arg.name}`, arg.meta);
     }
     // Get the status code if the status code is a number and is the first argument
     // This follows how http-errors deals with status codes
@@ -29,5 +31,5 @@ module.exports = (...args) => {
       argToSend = arg;
     }
   }
-  return _createError(status, argToSend, props);
+  return createError(status, argToSend, props);
 };


### PR DESCRIPTION
Renovate Bot failed updating http-errors to v2 in #72 so here's a manual update. This PR sets default values for status and argToSend variables so they're not undefined. This is my time touching any testing or elasticsearch stuff so let me know this is approach is correct.

These were the failed tests from #72 
```
 Create Error tests for Satellite
    ✕ should be an instance of type Error (1 ms)
    ✕ errors created without a status code should return a status of 500
    ✓ should have it's value, and message accessible through it's members (1 ms)
    ✕ should create an Error from a non Error object
    ✓ should create Error from ElasticSearch error object
  createServiceToken()
    ✓ should create a service token (1 ms)
  Redis()
    ✓ Redis ping command should return pong (5 ms)
  Elastic()
    Tests for regular Elastic()
      ✓ Testing the name property which should be a string (7 ms)
    Tests for mock Elastic()
      ✓ Should mock an API (3 ms)
      ✓ If an API is not mocked correctly, it should return a 404 (2 ms)
  fetch()
    ✓ fetch(url) should return 200 on success with a GET request (5 ms)
    ✓ fetch(url) should return 404 (2 ms)
    ✓ fetch(url, options) should return 201 on a successful POST request (5 ms)

  ● Create Error tests for Satellite › should be an instance of type Error

    TypeError: argument #1 unsupported type undefined

      30 |     }
      31 |   }
    > 32 |   return _createError(status, argToSend, props);
         |          ^
      33 | };
      34 |

      at _createError (node_modules/.pnpm/http-errors@2.0.0/node_modules/http-errors/index.js:68:13)
      at createError (src/create-error.js:32:10)
      at Object.<anonymous> (test.js:898:25)

  ● Create Error tests for Satellite › errors created without a status code should return a status of 500

    TypeError: argument #1 unsupported type undefined

      30 |     }
      31 |   }
    > 32 |   return _createError(status, argToSend, props);
         |          ^
      33 | };
      34 |

      at _createError (node_modules/.pnpm/http-errors@2.0.0/node_modules/http-errors/index.js:68:13)
      at createError (src/create-error.js:32:10)
      at Object.<anonymous> (test.js:903:12)

  ● Create Error tests for Satellite › should create an Error from a non Error object

    TypeError: argument #2 unsupported type undefined

      30 |     }
      31 |   }
    > 32 |   return _createError(status, argToSend, props);
         |          ^
      33 | };
      34 |

      at _createError (node_modules/.pnpm/http-errors@2.0.0/node_modules/http-errors/index.js:68:13)
      at createError (src/create-error.js:32:10)
      at Object.<anonymous> (test.js:922:23)

Test Suites: 1 failed, 1 total
Tests:       3 failed, 47 passed, 50 total
Snapshots:   0 total
Time:        1.515 s
Ran all test suites.
 ELIFECYCLE  Test failed. See above for more details.
Error: Process completed with exit code 1.
```

After adding default values
```
Test Suites: 1 passed, 1 total
Tests:       50 passed, 50 total
Snapshots:   0 total
Time:        3.142 s
Ran all test suites.
```